### PR TITLE
feat: support for implicit flow authentication (response_type=id_token)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # CHANGELOG
 
-## unreleased
-* Optional configuration for custom `response_type`
-
 ## v0.1.2
 * Optional params for `authorization_uri`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## unreleased
+* Optional configuration for custom `response_type`
+
 ## v0.1.2
 * Optional params for `authorization_uri`
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ config :my_app, :openid_connect_providers,
     client_id: "CLIENT_ID",
     client_secret: "CLIENT_SECRET",
     redirect_uri: "https://example.com/session",
-    scope: "openid email profile"
+    scope: "openid email profile",
+    response_type: "id_token" # if response_type is not specified, "code" will be used
   ]
 ```
 

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -100,7 +100,7 @@ defmodule OpenIDConnect do
       Map.merge(params, %{
         client_id: client_id(config),
         redirect_uri: redirect_uri(config),
-        response_type: "code",
+        response_type: response_type(config),
         scope: normalize_scope(provider, config[:scope])
       })
 
@@ -251,6 +251,10 @@ defmodule OpenIDConnect do
 
   defp redirect_uri(config) do
     Keyword.get(config, :redirect_uri)
+  end
+
+  defp response_type(config) do
+    Keyword.get(config, :response_type, "code")
   end
 
   defp discovery_document_uri(config) do

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -144,6 +144,19 @@ defmodule OpenIDConnectTest do
       end
     end
 
+    test "with custom response_type" do
+      {:ok, pid} = GenServer.start_link(MockWorker, [], name: :openid_connect)
+
+      try do
+        expected =
+          "https://accounts.google.com/o/oauth2/v2/auth?client_id=CLIENT_ID_1&redirect_uri=https%3A%2F%2Fdev.example.com%3A4200%2Fsession&response_type=id_token&scope=openid+email+profile"
+
+        assert OpenIDConnect.authorization_uri(:google_id_token) == expected
+      after
+        GenServer.stop(pid)
+      end
+    end
+
     test "with custom worker name" do
       {:ok, pid} = GenServer.start_link(MockWorker, [], name: :other_openid_worker)
 

--- a/test/support/mock_worker.ex
+++ b/test/support/mock_worker.ex
@@ -29,12 +29,23 @@ defmodule OpenIDConnect.MockWorker do
     {:reply, Map.get(state, :document), state}
   end
 
+  def handle_call({:discovery_document, :google_id_token}, _from, state) do
+    {:reply, Map.get(state, :document), state}
+  end
+
   def handle_call({:jwk, :google}, _from, state) do
     {:reply, Map.get(state, :jwk), state}
   end
 
   def handle_call({:config, :google}, _from, state) do
     {:reply, Map.get(state, :config), state}
+  end
+
+  def handle_call({:config, :google_id_token}, _from, state) do
+    config = state
+    |> Map.get(:config)
+    |> Keyword.put(:response_type, "id_token")
+    {:reply, config, state}
   end
 
   def handle_call({:put, key, value}, _from, state) do


### PR DESCRIPTION
PR for #14 to allow a `response_type` other than `"code"` to be used.