### PR TITLE
Support multiple response types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ config :my_app, :openid_connect_providers,
     client_id: "CLIENT_ID",
     client_secret: "CLIENT_SECRET",
     redirect_uri: "https://example.com/session",
+    response_type: "code",
     scope: "openid email profile"
   ]
 ```
@@ -84,11 +85,11 @@ is where the remainder of your steps will take place.
 
 #### Fetch the JWT
 
-The JSON Web Token (JWT) must be fetched using the `code` query param that was part of the redirect
-to your application:
+The JSON Web Token (JWT) must be fetched, using the key/value pairs from the `response_type` params that were
+part of the redirect to your application:
 
 ```elixir
-{:ok, tokens} = OpenIDConnect.fetch_tokens(:google, params["code"])
+{:ok, tokens} = OpenIDConnect.fetch_tokens(:google, %{code: params["code"]})
 ```
 
 #### Verify the JWT

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,5 +6,6 @@ config :openid_connect, :providers,
     client_id: "CLIENT_ID_1",
     client_secret: "CLIENT_SECRET_1",
     redirect_uri: "https://dev.example.com:4200/session",
-    scope: "openid email profile"
+    scope: "openid email profile",
+    response_type: "code id_token token"
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,5 +8,6 @@ config :openid_connect, :providers,
     client_id: "CLIENT_ID_1",
     client_secret: "CLIENT_SECRET_1",
     redirect_uri: "https://dev.example.com:4200/session",
-    scope: "openid email profile"
+    scope: "openid email profile",
+    response_type: "code id_token token"
   ]

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -110,7 +110,17 @@ defmodule OpenIDConnect do
   was requested during authorization. `params` may also include any one-off overrides for token
   fetching.
   """
-  def fetch_tokens(provider, params, name \\ :openid_connect) do
+  def fetch_tokens(provider, params, name \\ :openid_connect)
+
+  def fetch_tokens(provider, code, name) when is_binary(code) do
+    IO.warn(
+      "Deprecation: `OpenIDConnect.fetch_tokens/3` no longer takes a binary as the 2nd argument. Please refer to the docs for the new API."
+    )
+
+    fetch_tokens(provider, %{code: code}, name)
+  end
+
+  def fetch_tokens(provider, params, name) do
     uri = access_token_uri(provider, name)
     config = config(provider, name)
 

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -287,9 +287,7 @@ defmodule OpenIDConnect do
     response_type =
       config
       |> Keyword.get(:response_type)
-      |> String.split()
-      |> Enum.sort()
-      |> Enum.join(" ")
+      |> normalize_response_type(provider)
 
     response_types_supported = response_types_supported(provider, name)
 
@@ -305,6 +303,23 @@ defmodule OpenIDConnect do
           #{Enum.join(response_types_supported, "\n")}
           """
     end
+  end
+
+  defp normalize_response_type(response_type, provider)
+       when is_nil(response_type) or response_type == [] do
+    raise ArgumentError, "no response_type has been defined for provider `#{provider}`"
+  end
+
+  defp normalize_response_type(response_type, provider) when is_binary(response_type) do
+    response_type
+    |> String.split()
+    |> normalize_response_type(provider)
+  end
+
+  defp normalize_response_type(response_type, _provider) when is_list(response_type) do
+    response_type
+    |> Enum.sort()
+    |> Enum.join(" ")
   end
 
   defp response_types_supported(provider, name) do

--- a/test/openid_connect/worker_test.exs
+++ b/test/openid_connect/worker_test.exs
@@ -28,6 +28,7 @@ defmodule OpenIDConnect.WorkerTest do
       |> elem(1)
       |> Map.get(:body)
       |> Jason.decode!()
+      |> OpenIDConnect.normalize_discovery_document()
 
     expected_jwk =
       @google_certs
@@ -66,6 +67,7 @@ defmodule OpenIDConnect.WorkerTest do
       |> elem(1)
       |> Map.get(:body)
       |> Jason.decode!()
+      |> OpenIDConnect.normalize_discovery_document()
 
     assert expected_document == discovery_document
   end

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -28,6 +28,7 @@ defmodule OpenIDConnectTest do
         |> elem(1)
         |> Map.get(:body)
         |> Jason.decode!()
+        |> OpenIDConnect.normalize_discovery_document()
 
       expected_jwk =
         @google_certs

--- a/test/support/mock_worker.ex
+++ b/test/support/mock_worker.ex
@@ -5,6 +5,7 @@ defmodule OpenIDConnect.MockWorker do
                    |> elem(1)
                    |> Map.get(:body)
                    |> Jason.decode!()
+                   |> OpenIDConnect.normalize_discovery_document()
 
   @google_jwk Fixtures.load(:google, :certs)
               |> elem(1)


### PR DESCRIPTION
Authorization URI and token fetching should support the multiple response types
that each provider supports. In addition, this library should include some verification
of the requested response types.