### PR TITLE
Relax jason version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule OpenIDConnect.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 1.2"},
-      {:jason, "~> 1.0"},
+      {:jason, ">= 1.0.0"},
       {:jose, "~> 1.8"},
       {:earmark, "~> 1.2", only: :dev},
       {:ex_doc, "~> 0.18", only: :dev},


### PR DESCRIPTION
Ran into this issue because another dep required jason 1.1. It might also be worth making this an optional dependency so users could swap in something else, similar to how [phoenix does it](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix.ex).