### PR TITLE
Allow missing claims_supported

### DIFF
--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -208,11 +208,13 @@ defmodule OpenIDConnect do
 
   @doc false
   def normalize_discovery_document(discovery_document) do
+    # claims_supported may be missing as it is marked RECOMMENDED by the spec, default to an empty list
     sorted_claims_supported =
       discovery_document
-      |> Map.get("claims_supported")
+      |> Map.get("claims_supported", [])
       |> Enum.sort()
 
+    # response_types_supported's presence is REQUIRED by the spec, crash when missing
     sorted_response_types_supported =
       discovery_document
       |> Map.get("response_types_supported")

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -117,6 +117,24 @@ defmodule OpenIDConnectTest do
                {:error, :update_documents, %HTTPoison.Response{status_code: 404}}
     end
   end
+  
+  describe "normalize_discovery_document" do
+    test "defaults to empty list if claims_supported is missing" do
+      document_without_claims =
+        @google_document
+        |> elem(1)
+        |> Map.get(:body)
+        |> Jason.decode!()
+        |> Map.delete("claims_supported")
+
+      normalized_claims =
+        document_without_claims
+        |> OpenIDConnect.normalize_discovery_document()
+        |> Map.get("claims_supported")
+
+      assert normalized_claims == []
+    end
+  end
 
   describe "generating the authorization uri" do
     test "with default worker name" do


### PR DESCRIPTION
Some discovery documents do not contain the `claims_supported` key as it is marked as `RECOMMENDED` by the [spec](https://openid.net/specs/openid-connect-discovery-1_0.html). This leads to a crash in the current version. Maybe we could allow `claims_supported` to be missing and substitute it with an empty list in that case.

I wrote a fairly simple fix. What do you think?