### PR TITLE
Update supervisor spec to work with mix template

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Next add the `OpenIDConnect.Worker` to your app's supervisor along with your pro
 ```elixir
 children =
   [
-    worker(OpenIDConnect.Worker, [Application.get_env(:my_app, :openid_connect_providers)]),
+    Supervisor.Spec.worker(OpenIDConnect.Worker, [Application.get_env(:my_app, :openid_connect_providers)]),
   ]
 
 opts = [strategy: :one_for_one, name: MyApp.Supervisor]


### PR DESCRIPTION
This a quick fix for the fact new mix project templates don't include the `worker` function.

I guess it might be even better to actually set up a child spec and get to

```elixir
{OpenIDConnect.Worker, [Application.get_env(:my_app, :openid_connect_providers)]}
```