### PR TITLE
Ensure provider configs are a list

### DIFF
--- a/lib/openid_connect/worker.ex
+++ b/lib/openid_connect/worker.ex
@@ -9,7 +9,7 @@ defmodule OpenIDConnect.Worker do
 
   @refresh_time 60 * 60 * 1000
 
-  def start_link(provider_configs, name \\ :openid_connect) do
+  def start_link(provider_configs, name \\ :openid_connect) when is_list(provider_configs) do
     GenServer.start_link(__MODULE__, provider_configs, name: name)
   end
 


### PR DESCRIPTION
I got a fairly obtuse error when setting up. (see below) It was my spelling mistake that caused it, A difference between what I put in the config file and what I put in the application file.  

This change should just catch much earlier if a user doesn't pass a list of provider_configs when starting the Worker

```
Application kno exited: Kno.Application.start(:normal, []) returned an error: shutdown: failed to start child: OpenIDConnect.Worker
api_1      |     ** (EXIT) an exception was raised:
api_1      |         ** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): Ecto.Adapters.SQL.Stream, Postgrex.Stream, DBConnection.Stream, DBConnection.PrepareStream, List, Range, Stream, File.Stream, Function, HashSet, Map, MapSet, GenEvent.Stream, HashDict, Date.Range, IO.Stream
api_1      |             (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
api_1      |             (elixir) lib/enum.ex:141: Enumerable.reduce/3
api_1      |             (elixir) lib/enum.ex:3023: Enum.reverse/1
api_1      |             (elixir) lib/enum.ex:2670: Enum.to_list/1
api_1      |             (elixir) lib/map.ex:205: Map.new/2
api_1      |             (openid_connect) lib/openid_connect/worker.ex:22: OpenIDConnect.Worker.init/1
api_1      |             (stdlib) gen_server.erl:374: :gen_server.init_it/2
api_1      |             (stdlib) gen_server.erl:342: :gen_server.init_it/6
api_1      | ** (Mix) Could not start application kno: Kno.Application.start(:normal, []) returned an error: shutdown: failed to start child: OpenIDConnect.Worker
api_1      |     ** (EXIT) an exception was raised:
api_1      |         ** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): Ecto.Adapters.SQL.Stream, Postgrex.Stream, DBConnection.Stream, DBConnection.PrepareStream, List, Range, Stream, File.Stream, Function, HashSet, Map, MapSet, GenEvent.Stream, HashDict, Date.Range, IO.Stream
api_1      |             (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
api_1      |             (elixir) lib/enum.ex:141: Enumerable.reduce/3
api_1      |             (elixir) lib/enum.ex:3023: Enum.reverse/1
api_1      |             (elixir) lib/enum.ex:2670: Enum.to_list/1
api_1      |             (elixir) lib/map.ex:205: Map.new/2
api_1      |             (openid_connect) lib/openid_connect/worker.ex:22: OpenIDConnect.Worker.init/1
api_1      |             (stdlib) gen_server.erl:374: :gen_server.init_it/2
api_1      |             (stdlib) gen_server.erl:342: :gen_server.init_it/6
```