### PR TITLE
Allow setting HTTP Client options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# See: https://github.com/JakeBecker/elixir-ls
+.elixir_ls
+
+# vim .swp files
+*.swp

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -142,7 +142,7 @@ defmodule OpenIDConnect do
     headers = [{"Content-Type", "application/x-www-form-urlencoded"}]
 
     with {:ok, %HTTPoison.Response{status_code: status_code} = resp} when status_code in 200..299 <-
-           http_client().post(uri, {:form, form_body}, headers),
+           http_client().post(uri, {:form, form_body}, headers, http_client_options()),
          {:ok, json} <- Jason.decode(resp.body),
          {:ok, json} <- assert_json(json) do
       {:ok, json}
@@ -342,7 +342,7 @@ defmodule OpenIDConnect do
 
   defp fetch_resource(uri) do
     with {:ok, %HTTPoison.Response{status_code: status_code} = resp} when status_code in 200..299 <-
-           http_client().get(uri),
+           http_client().get(uri, [], http_client_options()),
          {:ok, json} <- Jason.decode(resp.body),
          {:ok, json} <- assert_json(json) do
       {:ok, json, remaining_lifetime(resp.headers)}
@@ -397,5 +397,9 @@ defmodule OpenIDConnect do
 
   defp http_client do
     Application.get_env(:openid_connect, :http_client, HTTPoison)
+  end
+
+  defp http_client_options do
+    Application.get_env(:openid_connect, :http_client_options, [])
   end
 end

--- a/test/openid_connect/worker_test.exs
+++ b/test/openid_connect/worker_test.exs
@@ -93,9 +93,9 @@ defmodule OpenIDConnect.WorkerTest do
 
   defp mock_http_requests do
     HTTPClientMock
-    |> expect(:get, fn "https://accounts.google.com/.well-known/openid-configuration" ->
+    |> expect(:get, fn "https://accounts.google.com/.well-known/openid-configuration", _headers, _opts ->
       @google_document
     end)
-    |> expect(:get, fn "https://www.googleapis.com/oauth2/v3/certs" -> @google_certs end)
+    |> expect(:get, fn "https://www.googleapis.com/oauth2/v3/certs", _headers, _opts -> @google_certs end)
   end
 end


### PR DESCRIPTION
In our scenario, we're running Keycloak for development with a self signed cert.  It'd be great to be able to use self signed certs in the 'dev' mix environment with this client.

This PR adds an optional config setting to set (primarily HTTPoison) HTTP
client settings, for example:

    # config/dev.exs
    config :openid_connect,
      http_client_options: [ssl: [{:verify, :verify_none}]]