### PR TITLE
fix: edge case verification failure

### DIFF
--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -179,6 +179,9 @@ defmodule OpenIDConnect do
 
       {false, _claims, _jwk} ->
         {:error, :verify, "verification failed"}
+
+      _ ->
+        {:error, :verify, "verification error"}
     end
   end
 


### PR DESCRIPTION
I stumbled across this edge case which was throwing the following:

```
** (WithClauseError) no with clause matching: {:error, {:case_clause, 44}}
    (openid_connect 0.2.2) lib/openid_connect.ex:165: OpenIDConnect.verify/3
```

Maybe a fix should also be applied in JOSE