### PR TITLE
Support for configuring token endpoint authentication method

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -10,4 +10,13 @@ config :openid_connect, :providers,
     redirect_uri: "https://dev.example.com:4200/session",
     scope: "openid email profile",
     response_type: "code id_token token"
+  ],
+  google_auth_basic: [
+    discovery_document_uri: "https://accounts.google.com/.well-known/openid-configuration",
+    client_id: "CLIENT_ID_1",
+    client_secret: "CLIENT_SECRET_1",
+    redirect_uri: "https://dev.example.com:4200/session",
+    scope: "openid email profile",
+    response_type: "code id_token token",
+    token_endpoint_auth_method: "client_secret_basic"
   ]


### PR DESCRIPTION
Support for configuring token endpoint authentication method with the setting `:token_endpoint_auth_method` per provider. This defaults to `"client_secret_post"` which was originally supported. Another method `"client_secret_basic"` is now also supported, which uses HTTP Basic authentication.

I needed this to support [Vipps Login](https://github.com/vippsas/vipps-login-api) as OIDC provider, which unfortunately doesn't support the `"client_secret_post"` authentication method.
