### PR TITLE
Support for userinfo endpoint

### DIFF
--- a/test/fixtures/google/userinfo.exs
+++ b/test/fixtures/google/userinfo.exs
@@ -1,0 +1,32 @@
+%HTTPoison.Response{
+  body: %{
+    "sub" => "353690423699814251281",
+    "name" => "Ada Lovelace",
+    "given_name" => "Ada",
+    "family_name" => "Lovelace",
+    "picture" =>
+      "https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg",
+    "email" => "ada@example.com",
+    "email_verified" => true,
+    "locale" => "en"
+  },
+  headers: [
+    {"Date", "Thu, 17 Dec 2020 14:29:16 GMT"},
+    {"Cache-Control", "no-cache, no-store, max-age=0, must-revalidate"},
+    {"Expires", "Mon, 01 Jan 1990 00:00:00 GMT"},
+    {"Pragma", "no-cache"},
+    {"Content-Type", "application/json; charset=utf-8"},
+    {"Vary", "X-Origin"},
+    {"Vary", "Referer"},
+    {"Server", "ESF"},
+    {"X-XSS-Protection", "0"},
+    {"X-Frame-Options", "SAMEORIGIN"},
+    {"X-Content-Type-Options", "nosniff"},
+    {"Alt-Svc",
+     "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""},
+    {"Accept-Ranges", "none"},
+    {"Vary", "Origin,Accept-Encoding"},
+    {"Transfer-Encoding", "chunked"}
+  ],
+  status_code: 200
+}


### PR DESCRIPTION
I needed this when working with [Vipps Login](https://github.com/vippsas/vipps-login-api) as OIDC provider since it doesn't return any of the information requested in the scope as claims, but requires that it's obtained with a request to the userinfo endpoint.
