### PR TITLE
fix authorization_uri/1 example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ get("/session/authorization-uri", SessionController, :authorization_uri)
 # you could also take the `provider` as a query param to pass into the function
 def authorization_uri(conn, _params) do
   google_config = Application.fetch_env!(:my_app, :google_oidc_config)
-  json(conn, %{uri: OpenIDConnect.authorization_uri(google_config)})
+  {:ok, uri} = OpenIDConnect.authorization_uri(google_config)
+  
+  json(conn, %{uri: uri})
 end
 
 # The `Authentication` module here is an imaginary interface for setting session state


### PR DESCRIPTION
authorization_uri/1 now returns an :ok tuple.