### PR TITLE
Support grant types other than "authorization_code"

### DIFF
--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -77,6 +77,7 @@ defmodule OpenIDConnect do
           config(),
           redirect_uri :: redirect_uri(),
           params :: %{optional(atom) => term()}
+        ) :: {:ok, uri :: String.t()} | {:error, term()}
   def authorization_uri(config, redirect_uri, params \\ %{}) do
     discovery_document_uri = config.discovery_document_uri
 

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -50,7 +50,6 @@ defmodule OpenIDConnect do
           required(:discovery_document_uri) => discovery_document_uri(),
           required(:client_id) => client_id(),
           required(:client_secret) => client_secret(),
-          optional(:redirect_uri) => redirect_uri(),
           required(:response_type) => response_type(),
           required(:scope) => scope(),
           optional(:leeway) => non_neg_integer()
@@ -74,8 +73,10 @@ defmodule OpenIDConnect do
   > It is *highly suggested* that you add the `state` param for security reasons. Your
   > OpenID Connect provider should have more information on this topic.
   """
-  @spec authorization_uri(config(), params :: %{optional(atom) => term()}) ::
-          {:ok, uri :: String.t()} | {:error, term()}
+  @spec authorization_uri(
+          config(),
+          redirect_uri :: redirect_uri(),
+          params :: %{optional(atom) => term()}
   def authorization_uri(config, redirect_uri, params \\ %{}) do
     discovery_document_uri = config.discovery_document_uri
 


### PR DESCRIPTION
This is a replacement of https://github.com/DockYard/openid_connect/pull/52 because that PR was based off our `master` branch and extra changes piled up on top of intended ones.

----

I think this is another thing that we might want to clean up before pushing 1.0 to hex.pm.

This PR:
**Removes the hardcoded "authorization_code" grant type from `fetch_tokens/2`.**

Before you could override the `grant_type` using params but because the code assumed this grant type by default it always added `redirect_uri` to the params too, which can not be removed. 

There are two reasons to remove it: 
- typically `redirect_uri` is retrieved in a Phoenix controller, but if you want to use a `refresh_token` grant in a background job you don't know that `redirect_uri` beforehand unless you have access to phoenix endpoint (which is not true for umbrella apps), and storing it doesn't make a lot of sense just to work around this function limitations;
- we really should not send parameters that are not part of the spec to the token endpoint because if some provider starts to validate our requests against the spec the payload will be invalid.

**Additionally, I completely removed `redirect_uri` from the config map and made it a function argument for `authorization_uri/3`.** 

Again, this is because it's the only required argument there, which should not be hidden behind a map, and it doesn't make a ton of sense to store this URI in the memory or database. Especially when the route can be changed and then you will have to migrate the data.