### PR TITLE
feat: publish to Hex.pm upon Github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Publish to Hex.pm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  Publish:
+    runs-on: ubuntu-latest
+    env:
+      HEX_API_KEY: ${{ secrets.HEXPM_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18"
+          otp-version: "27"
+      - run: mix deps.get
+      - run: mix compile --docs
+      - run: mix hex.publish --yes


### PR DESCRIPTION
Once this is merged, if we tag a release in Github, it will publish to Hex.pm.

@bcardarella can you add a Hex API key to the repo under `HEXPM_SECRET`?