### PR TITLE
Optionally ignore audience matching in verify function

### DIFF
--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -113,19 +113,12 @@ defmodule OpenIDConnect do
   @type scope :: [String.t()] | String.t()
 
   @typedoc """
-  `OpenIDConnect.verify/3` operations to ignore.
-
-  - `:audience_matching` - Ignores the "aud" (audience) claim verification that ensures the token
-    is intended for your application.
-  """
-  @type verify_operations_to_ignore :: :audience_matching
-
-  @typedoc """
   Options for `OpenIDConnect.verify/3`:
 
-  - `:ignore` - An atom or a list of atoms with operations to ignore.
+  - `:ignore_claims` - A list of claims to not be verified.
+    Available claim options to use: `"aud"`.
   """
-  @type verify_opts :: [ignore: verify_operations_to_ignore() | [verify_operations_to_ignore()]]
+  @type verify_opts :: [ignore_claims: [String.t()]]
 
   @typedoc """
   The configuration of a OpenID provider.
@@ -505,10 +498,8 @@ defmodule OpenIDConnect do
 
   ## Options
 
-  - `:ignore` - An atom or a list of atoms with operations to ignore. Defaults to an empty list.
-    Operations that can be ignored:
-    - `:audience_matching` - Ignores the "aud" (audience) claim verification that ensures the
-      token is intended for your application.
+  - `:ignore_claims` - A list of claims to not be verified.
+    Available claim options to use: `"aud"`.
 
   ## Returns
 
@@ -535,6 +526,16 @@ defmodule OpenIDConnect do
   name = claims["name"]           # User's name (if in scope)
   picture = claims["picture"]     # URL to user's profile picture (if available)
   issuer = claims["iss"]          # Identifies the token issuer
+  ```
+
+  Ignoring "aud" claim verification:
+
+  ```elixir
+  google_config = %{client_id: "aaccaecd-fd29-46e7-be3e-58a99f355157", ...}
+
+  {:ok, claims} = OpenIDConnect.verify(google_config, id_token, ignore_claims: ["aud"])
+
+  audience = claims["aud"]        # b52bc817-2ab3-4aba-bd6e-286713d542f0
   ```
 
   ## Security Warning
@@ -630,7 +631,7 @@ defmodule OpenIDConnect do
   defp verify_aud_claim(claims, expected_aud, opts) do
     case Map.fetch(claims, "aud") do
       {:ok, aud} ->
-        if ignore_audience_matching?(opts) or audience_matches?(aud, expected_aud),
+        if ignore_claim?(opts, "aud") or audience_matches?(aud, expected_aud),
           do: :ok,
           else: {:error, "aud", "token is intended for another application"}
 
@@ -639,7 +640,7 @@ defmodule OpenIDConnect do
     end
   end
 
-  defp ignore_audience_matching?(opts), do: :audience_matching in List.wrap(opts[:ignore])
+  defp ignore_claim?(opts, claim), do: claim in List.wrap(opts[:ignore_claims])
 
   defp audience_matches?(aud, expected_aud) when is_list(aud), do: Enum.member?(aud, expected_aud)
   defp audience_matches?(aud, expected_aud), do: aud === expected_aud

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -659,7 +659,7 @@ defmodule OpenIDConnect do
         {:error, "aud", "missing"}
     end
   end
-  
+
   defp audience_matches?(aud, expected_aud) when is_list(aud), do: Enum.member?(aud, expected_aud)
   defp audience_matches?(aud, expected_aud), do: aud === expected_aud
 

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -2,8 +2,8 @@ defmodule OpenIDConnect do
   @moduledoc """
   OpenID Connect client library for Elixir.
 
-  This library provides a complete implementation of the [OpenID Connect](https://openid.net/connect/) 
-  authentication protocol, which is built on top of OAuth 2.0. It handles the complete authentication 
+  This library provides a complete implementation of the [OpenID Connect](https://openid.net/connect/)
+  authentication protocol, which is built on top of OAuth 2.0. It handles the complete authentication
   flow including:
 
   * Generating authorization URIs for redirecting users to identity providers
@@ -111,6 +111,14 @@ defmodule OpenIDConnect do
   OAuth 2.0 Scope Values that the Client is declaring that it will restrict itself to using.
   """
   @type scope :: [String.t()] | String.t()
+
+  @typedoc """
+  Options for `OpenIDConnect.verify/3`:
+
+  - `:ignore_audience_matching?` - If set to `true`, the `"aud"` claim value will not be
+    validated. Defaults to `false`.
+  """
+  @type verify_opts :: [ignore_audience_matching?: boolean()]
 
   @typedoc """
   The configuration of a OpenID provider.
@@ -434,7 +442,7 @@ defmodule OpenIDConnect do
     google_config,
     %{
       code: params["code"],
-      redirect_uri: "https://example.com/auth/callback" 
+      redirect_uri: "https://example.com/auth/callback"
     }
   )
 
@@ -481,12 +489,18 @@ defmodule OpenIDConnect do
 
   1. The token's signature is valid and was signed by the provider's key
   2. The token has not expired (checking the "exp" claim)
-  3. The token is intended for your application (checking the "aud" claim)
+  3. The token is intended for your application (checking the "aud" claim). This validation can
+     be skipped by using the `ignore_audience_matching?: true` option.
 
   ## Parameters
 
   * `config` - The provider configuration map
   * `jwt` - The ID token string (a JSON Web Token) from the tokens response
+
+  ## Options
+
+  - `:ignore_audience_matching?` - If set to `true`, the `"aud"` claim value will not be
+    validated. Defaults to `false`.
 
   ## Returns
 
@@ -500,7 +514,8 @@ defmodule OpenIDConnect do
   2. The "exp" (expiration) claim is checked to ensure the token has not expired.
      A configurable leeway (default: 30 seconds) is allowed to account for clock skew.
   3. The "aud" (audience) claim is verified to ensure the token is intended for your
-     application, as identified by your client_id.
+     application, as identified by your client_id. This validation can be skipped by using the
+     `ignore_audience_matching?: true` option.
 
   ## Example
 
@@ -520,9 +535,9 @@ defmodule OpenIDConnect do
   Always verify tokens before trusting their contents. Never use token data for
   authentication purposes without verification, as tokens could be forged or tampered with.
   """
-  @spec verify(config(), jwt :: String.t()) ::
+  @spec verify(config(), jwt :: String.t(), verify_opts()) ::
           {:ok, claims :: map()} | {:error, term()}
-  def verify(config, jwt) do
+  def verify(config, jwt, opts \\ []) do
     discovery_document_uri = config.discovery_document_uri
 
     with {:ok, protected} <- peek_protected(jwt),
@@ -531,7 +546,7 @@ defmodule OpenIDConnect do
          {:ok, document} <- Document.fetch_document(discovery_document_uri),
          {true, claims, _jwk} <- verify_signature(document.jwks, token_alg, jwt),
          {:ok, unverified_claims} <- Jason.decode(claims),
-         {:ok, verified_claims} <- verify_claims(unverified_claims, config) do
+         {:ok, verified_claims} <- verify_claims(unverified_claims, config, opts) do
       {:ok, verified_claims}
     else
       {:error, %Jason.DecodeError{}} ->
@@ -578,12 +593,12 @@ defmodule OpenIDConnect do
   defp verify_signature(%JOSE.JWK{} = jwk, token_alg, jwt),
     do: JOSE.JWS.verify_strict(jwk, [token_alg], jwt)
 
-  defp verify_claims(claims, config) do
+  defp verify_claims(claims, config, opts) do
     leeway = Map.get(config, :leeway, 30)
     client_id = Map.fetch!(config, :client_id)
 
     with :ok <- verify_exp_claim(claims, leeway),
-         :ok <- verify_aud_claim(claims, client_id) do
+         :ok <- verify_aud_claim(claims, client_id, opts) do
       {:ok, claims}
     end
   end
@@ -605,10 +620,10 @@ defmodule OpenIDConnect do
     end
   end
 
-  defp verify_aud_claim(claims, expected_aud) do
+  defp verify_aud_claim(claims, expected_aud, opts) do
     case Map.fetch(claims, "aud") do
       {:ok, aud} ->
-        if audience_matches?(aud, expected_aud),
+        if opts[:ignore_audience_matching?] == true or audience_matches?(aud, expected_aud),
           do: :ok,
           else: {:error, "aud", "token is intended for another application"}
 

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -113,12 +113,19 @@ defmodule OpenIDConnect do
   @type scope :: [String.t()] | String.t()
 
   @typedoc """
+  `OpenIDConnect.verify/3` operations to ignore.
+
+  - `:audience_matching` - Ignores the "aud" (audience) claim verification that ensures the token
+    is intended for your application.
+  """
+  @type verify_operations_to_ignore :: :audience_matching
+
+  @typedoc """
   Options for `OpenIDConnect.verify/3`:
 
-  - `:ignore_audience_matching?` - If set to `true`, the `"aud"` claim value will not be
-    validated. Defaults to `false`.
+  - `:ignore` - An atom or a list of atoms with operations to ignore.
   """
-  @type verify_opts :: [ignore_audience_matching?: boolean()]
+  @type verify_opts :: [ignore: verify_operations_to_ignore() | [verify_operations_to_ignore()]]
 
   @typedoc """
   The configuration of a OpenID provider.
@@ -489,8 +496,7 @@ defmodule OpenIDConnect do
 
   1. The token's signature is valid and was signed by the provider's key
   2. The token has not expired (checking the "exp" claim)
-  3. The token is intended for your application (checking the "aud" claim). This validation can
-     be skipped by using the `ignore_audience_matching?: true` option.
+  3. The token is intended for your application (checking the "aud" claim)
 
   ## Parameters
 
@@ -499,8 +505,10 @@ defmodule OpenIDConnect do
 
   ## Options
 
-  - `:ignore_audience_matching?` - If set to `true`, the `"aud"` claim value will not be
-    validated. Defaults to `false`.
+  - `:ignore` - An atom or a list of atoms with operations to ignore. Defaults to an empty list.
+    Operations that can be ignored:
+    - `:audience_matching` - Ignores the "aud" (audience) claim verification that ensures the
+      token is intended for your application.
 
   ## Returns
 
@@ -514,8 +522,7 @@ defmodule OpenIDConnect do
   2. The "exp" (expiration) claim is checked to ensure the token has not expired.
      A configurable leeway (default: 30 seconds) is allowed to account for clock skew.
   3. The "aud" (audience) claim is verified to ensure the token is intended for your
-     application, as identified by your client_id. This validation can be skipped by using the
-     `ignore_audience_matching?: true` option.
+     application, as identified by your client_id.
 
   ## Example
 
@@ -623,7 +630,7 @@ defmodule OpenIDConnect do
   defp verify_aud_claim(claims, expected_aud, opts) do
     case Map.fetch(claims, "aud") do
       {:ok, aud} ->
-        if opts[:ignore_audience_matching?] == true or audience_matches?(aud, expected_aud),
+        if ignore_audience_matching?(opts) or audience_matches?(aud, expected_aud),
           do: :ok,
           else: {:error, "aud", "token is intended for another application"}
 
@@ -631,6 +638,8 @@ defmodule OpenIDConnect do
         {:error, "aud", "missing"}
     end
   end
+
+  defp ignore_audience_matching?(opts), do: :audience_matching in List.wrap(opts[:ignore])
 
   defp audience_matches?(aud, expected_aud) when is_list(aud), do: Enum.member?(aud, expected_aud)
   defp audience_matches?(aud, expected_aud), do: aud === expected_aud

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -620,7 +620,7 @@ defmodule OpenIDConnect do
       verify_exp_claim(claims, leeway)
     end
   end
- 
+
   defp ignore_claim?(opts, claim), do: claim in List.wrap(opts[:ignore_claims])
 
   defp verify_exp_claim(claims, leeway) do
@@ -639,7 +639,7 @@ defmodule OpenIDConnect do
         {:error, "exp", "missing"}
     end
   end
-  
+
   defp maybe_verify_aud_claim(claims, expected_aud, opts) do
     if ignore_claim?(opts, "aud") do
       :ok

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -546,6 +546,8 @@ defmodule OpenIDConnect do
   @spec verify(config(), jwt :: String.t(), verify_opts()) ::
           {:ok, claims :: map()} | {:error, term()}
   def verify(config, jwt, opts \\ []) do
+    opts = Keyword.validate!(opts, ignore_claims: [])
+
     discovery_document_uri = config.discovery_document_uri
 
     with {:ok, protected} <- peek_protected(jwt),
@@ -605,11 +607,21 @@ defmodule OpenIDConnect do
     leeway = Map.get(config, :leeway, 30)
     client_id = Map.fetch!(config, :client_id)
 
-    with :ok <- verify_exp_claim(claims, leeway),
-         :ok <- verify_aud_claim(claims, client_id, opts) do
+    with :ok <- maybe_verify_exp_claim(claims, leeway, opts),
+         :ok <- maybe_verify_aud_claim(claims, client_id, opts) do
       {:ok, claims}
     end
   end
+
+  defp maybe_verify_exp_claim(claims, leeway, opts) do
+    if ignore_claim?(opts, "exp") do
+      :ok
+    else
+      verify_exp_claim(claims, leeway)
+    end
+  end
+ 
+  defp ignore_claim?(opts, claim), do: claim in List.wrap(opts[:ignore_claims])
 
   defp verify_exp_claim(claims, leeway) do
     case Map.fetch(claims, "exp") do
@@ -627,11 +639,19 @@ defmodule OpenIDConnect do
         {:error, "exp", "missing"}
     end
   end
+  
+  defp maybe_verify_aud_claim(claims, expected_aud, opts) do
+    if ignore_claim?(opts, "aud") do
+      :ok
+    else
+      verify_aud_claim(claims, expected_aud)
+    end
+  end
 
-  defp verify_aud_claim(claims, expected_aud, opts) do
+  defp verify_aud_claim(claims, expected_aud) do
     case Map.fetch(claims, "aud") do
       {:ok, aud} ->
-        if ignore_claim?(opts, "aud") or audience_matches?(aud, expected_aud),
+        if audience_matches?(aud, expected_aud),
           do: :ok,
           else: {:error, "aud", "token is intended for another application"}
 
@@ -639,9 +659,7 @@ defmodule OpenIDConnect do
         {:error, "aud", "missing"}
     end
   end
-
-  defp ignore_claim?(opts, claim), do: claim in List.wrap(opts[:ignore_claims])
-
+  
   defp audience_matches?(aud, expected_aud) when is_list(aud), do: Enum.member?(aud, expected_aud)
   defp audience_matches?(aud, expected_aud), do: aud === expected_aud
 

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -2,8 +2,8 @@ defmodule OpenIDConnect do
   @moduledoc """
   OpenID Connect client library for Elixir.
 
-  This library provides a complete implementation of the [OpenID Connect](https://openid.net/connect/)
-  authentication protocol, which is built on top of OAuth 2.0. It handles the complete authentication
+  This library provides a complete implementation of the [OpenID Connect](https://openid.net/connect/) 
+  authentication protocol, which is built on top of OAuth 2.0. It handles the complete authentication 
   flow including:
 
   * Generating authorization URIs for redirecting users to identity providers
@@ -442,7 +442,7 @@ defmodule OpenIDConnect do
     google_config,
     %{
       code: params["code"],
-      redirect_uri: "https://example.com/auth/callback"
+      redirect_uri: "https://example.com/auth/callback" 
     }
   )
 

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -561,7 +561,7 @@ defmodule OpenIDConnectTest do
     returns claims when \
     encoded token is valid, \
     aud is for another application, \
-    and ignore_audience_matching? is true\
+    and [ignore: :audience_matching] option is set\
     """ do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)
@@ -581,7 +581,34 @@ defmodule OpenIDConnectTest do
         |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
         |> JOSE.JWS.compact()
 
-      assert verify(config, token, ignore_audience_matching?: true) == {:ok, claims}
+      assert verify(config, token, ignore: :audience_matching) == {:ok, claims}
+    end
+
+    test """
+    returns claims when \
+    encoded token is valid, \
+    aud is for another application, \
+    and [ignore: [:audience_matching]] option is set\
+    """ do
+      {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
+      jwk = JOSE.JWK.from(jwks)
+      {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
+
+      {_bypass, uri} = start_fixture("vault", %{"jwks" => jwk_pubkey})
+      config = %{@config | discovery_document_uri: uri}
+
+      claims = %{
+        "email" => "brian@example.com",
+        "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
+        "aud" => "foo"
+      }
+
+      {_alg, token} =
+        jwk
+        |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
+        |> JOSE.JWS.compact()
+
+      assert verify(config, token, ignore: [:audience_matching]) == {:ok, claims}
     end
 
     test "returns error when token is altered" do

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -561,7 +561,7 @@ defmodule OpenIDConnectTest do
     returns claims when \
     encoded token is valid, \
     aud is for another application, \
-    and [ignore: :audience_matching] option is set\
+    and [ignore_claims: ["aud"]] option is set\
     """ do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)
@@ -581,34 +581,7 @@ defmodule OpenIDConnectTest do
         |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
         |> JOSE.JWS.compact()
 
-      assert verify(config, token, ignore: :audience_matching) == {:ok, claims}
-    end
-
-    test """
-    returns claims when \
-    encoded token is valid, \
-    aud is for another application, \
-    and [ignore: [:audience_matching]] option is set\
-    """ do
-      {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
-      jwk = JOSE.JWK.from(jwks)
-      {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
-
-      {_bypass, uri} = start_fixture("vault", %{"jwks" => jwk_pubkey})
-      config = %{@config | discovery_document_uri: uri}
-
-      claims = %{
-        "email" => "brian@example.com",
-        "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
-        "aud" => "foo"
-      }
-
-      {_alg, token} =
-        jwk
-        |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
-        |> JOSE.JWS.compact()
-
-      assert verify(config, token, ignore: [:audience_matching]) == {:ok, claims}
+      assert verify(config, token, ignore_claims: ["aud"]) == {:ok, claims}
     end
 
     test "returns error when token is altered" do

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -557,6 +557,33 @@ defmodule OpenIDConnectTest do
       assert verify(config, token) == {:error, {:invalid_jwt, "invalid aud claim: missing"}}
     end
 
+    test """
+    returns claims when \
+    encoded token is valid, \
+    aud is for another application, \
+    and ignore_audience_matching? is true\
+    """ do
+      {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
+      jwk = JOSE.JWK.from(jwks)
+      {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
+
+      {_bypass, uri} = start_fixture("vault", %{"jwks" => jwk_pubkey})
+      config = %{@config | discovery_document_uri: uri}
+
+      claims = %{
+        "email" => "brian@example.com",
+        "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
+        "aud" => "foo"
+      }
+
+      {_alg, token} =
+        jwk
+        |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
+        |> JOSE.JWS.compact()
+
+      assert verify(config, token, ignore_audience_matching?: true) == {:ok, claims}
+    end
+
     test "returns error when token is altered" do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -512,6 +512,59 @@ defmodule OpenIDConnectTest do
       assert verify(config, token) == {:error, {:invalid_jwt, "invalid exp claim: missing"}}
     end
 
+    test """
+    returns claims when \
+    encoded token is valid, \
+    encoded token is expired, \
+    and [ignore_claims: ["exp"]] option is set\
+    """ do
+      {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
+      jwk = JOSE.JWK.from(jwks)
+      {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
+
+      {_bypass, uri} = start_fixture("vault", %{"jwks" => jwk_pubkey})
+      config = %{@config | discovery_document_uri: uri}
+
+      claims = %{
+        "email" => "brian@example.com",
+        "exp" => DateTime.utc_now() |> DateTime.add(-31, :second) |> DateTime.to_unix(),
+        "aud" => config.client_id
+      }
+
+      {_alg, token} =
+        jwk
+        |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
+        |> JOSE.JWS.compact()
+
+      assert verify(config, token, ignore_claims: ["exp"]) == {:ok, claims}
+    end
+
+    test """
+    returns claims when \
+    encoded token is valid, \
+    encoded token expiration is not set, \
+    and [ignore_claims: ["exp"]] option is set\
+    """ do
+      {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
+      jwk = JOSE.JWK.from(jwks)
+      {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
+
+      {_bypass, uri} = start_fixture("vault", %{"jwks" => jwk_pubkey})
+      config = %{@config | discovery_document_uri: uri}
+
+      claims = %{
+        "email" => "brian@example.com",
+        "aud" => config.client_id
+      }
+
+      {_alg, token} =
+        jwk
+        |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
+        |> JOSE.JWS.compact()
+
+      assert verify(config, token, ignore_claims: ["exp"]) == {:ok, claims}
+    end
+
     test "returns error when aud claim is for another application" do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)
@@ -574,6 +627,32 @@ defmodule OpenIDConnectTest do
         "email" => "brian@example.com",
         "exp" => DateTime.utc_now() |> DateTime.add(10, :second) |> DateTime.to_unix(),
         "aud" => "foo"
+      }
+
+      {_alg, token} =
+        jwk
+        |> JOSE.JWS.sign(Jason.encode!(claims), %{"alg" => "RS256"})
+        |> JOSE.JWS.compact()
+
+      assert verify(config, token, ignore_claims: ["aud"]) == {:ok, claims}
+    end
+
+    test """
+    returns claims when \
+    encoded token is valid, \
+    claim is not set, \
+    and [ignore_claims: ["aud"]] option is set\
+    """ do
+      {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
+      jwk = JOSE.JWK.from(jwks)
+      {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
+
+      {_bypass, uri} = start_fixture("vault", %{"jwks" => jwk_pubkey})
+      config = %{@config | discovery_document_uri: uri}
+
+      claims = %{
+        "email" => "brian@example.com",
+        "exp" => DateTime.utc_now() |> DateTime.to_unix()
       }
 
       {_alg, token} =

--- a/test/openid_connect_test.exs
+++ b/test/openid_connect_test.exs
@@ -512,12 +512,7 @@ defmodule OpenIDConnectTest do
       assert verify(config, token) == {:error, {:invalid_jwt, "invalid exp claim: missing"}}
     end
 
-    test """
-    returns claims when \
-    encoded token is valid, \
-    encoded token is expired, \
-    and [ignore_claims: ["exp"]] option is set\
-    """ do
+    test "returns claims when encoded token is expired and exp ignore claim option is set" do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)
       {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
@@ -539,12 +534,7 @@ defmodule OpenIDConnectTest do
       assert verify(config, token, ignore_claims: ["exp"]) == {:ok, claims}
     end
 
-    test """
-    returns claims when \
-    encoded token is valid, \
-    encoded token expiration is not set, \
-    and [ignore_claims: ["exp"]] option is set\
-    """ do
+    test "returns claims when exp claim is not set and exp ignore claim option is set" do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)
       {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
@@ -610,12 +600,7 @@ defmodule OpenIDConnectTest do
       assert verify(config, token) == {:error, {:invalid_jwt, "invalid aud claim: missing"}}
     end
 
-    test """
-    returns claims when \
-    encoded token is valid, \
-    aud is for another application, \
-    and [ignore_claims: ["aud"]] option is set\
-    """ do
+    test "returns claims when aud is for another application and aud ignore claim option is set" do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)
       {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)
@@ -637,12 +622,7 @@ defmodule OpenIDConnectTest do
       assert verify(config, token, ignore_claims: ["aud"]) == {:ok, claims}
     end
 
-    test """
-    returns claims when \
-    encoded token is valid, \
-    claim is not set, \
-    and [ignore_claims: ["aud"]] option is set\
-    """ do
+    test "returns claims when aud claim is not set and aud ignore claim option is set" do
       {jwks, []} = Code.eval_file("test/fixtures/jwks/jwk.exs")
       jwk = JOSE.JWK.from(jwks)
       {_, jwk_pubkey} = JOSE.JWK.to_public_map(jwk)


### PR DESCRIPTION
Hi DockYard :wave: 

OneLogin provides a feature to allow authentication between different clients: https://developers.onelogin.com/openid-connect/api/client-credentials-grant

OneLogin validates if the client is authorized to access a given "resource" from connected clients.

Unfortunately, the `"aud"`  value in the claims will not be the resource's client ID, it will be the caller's client ID. This cannot be changed.

To work around this behavior, I created this PR to allow your library to skip the audience matching validation if an option is set.

Let me know if the changes are reasonable or if I need to adjust or improve further.