### PR TITLE
fix: Make userinfo_endpoint optional

### DIFF
--- a/lib/openid_connect/document.ex
+++ b/lib/openid_connect/document.ex
@@ -123,7 +123,7 @@ defmodule OpenIDConnect.Document do
         authorization_endpoint: Map.fetch!(document_json, "authorization_endpoint"),
         end_session_endpoint: Map.get(document_json, "end_session_endpoint"),
         token_endpoint: Map.fetch!(document_json, "token_endpoint"),
-        userinfo_endpoint: Map.fetch!(document_json, "userinfo_endpoint"),
+        userinfo_endpoint: Map.get(document_json, "userinfo_endpoint"),
         response_types_supported:
           Map.get(document_json, "response_types_supported")
           |> Enum.map(fn response_type ->


### PR DESCRIPTION
resolves https://github.com/DockYard/openid_connect/issues/74

This PR simply makes `userinfo_endpoint` optional, which makes it possible to validate Apple tokens using their openID configuration. 

Given that "userinfo_endpoint" is not present in `required_keys` I think this is a relatively non-controversial change, and IMO a test does not need to be added here (before, a document without this key would result in an exception, rather than `:invalid_document` being returned) But happy to add one if needed!

(side note: Not particularly important for this PR, but  https://github.com/dockyard/styleguides 404s for me. )